### PR TITLE
feat: site environment info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.5.0] - 2025-04-07
+
+### Added
+  - **`site.getEnvironment()`:**
+    - This method is meant to retrieve whether if you are in production or a dev environment (returns "development" or "production").
+
+### Fixed
+  - **`dubug` property:**
+    - disabled all console logs and warning in production
+
 ## [1.4.3] - 2025-04-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 	- [Tab Buttons & Navigation Helpers](#tab-buttons--navigation-helpers)
 	- [Action Interception](#action-interception)
 	- [Workflow and Transition Definitions](#workflow-transition-and-action-retrieval)
+	- [Site Information](#site-information)
 - [Contributing](#contributing)
 
 ---
@@ -409,6 +410,28 @@ if (Utils.workflow.getActions().includes("Approve")) {
   console.log("Approval action available.");
 }
 
+```
+
+### Site information
+
+#### Get installed apps and versions
+```javascript
+Utils.site.apps()
+```
+Log the installed apps e.g. [ { name: "ERPNext", version: "v13.0.1" }, ... ]
+```javascript
+const apps = Utils.site.apps();
+console.log(apps);
+
+```
+
+#### Get Environment
+```javascript
+Utils.site.getEnvironment()
+```
+Logs the current environment ("development" or "production")
+```javascript
+console.log(`Current Environment: ${Utils.site.getEnvironment()}`);
 ```
 ---
 

--- a/utils.js
+++ b/utils.js
@@ -393,13 +393,13 @@ const Utils = (function () {
 					frm.fields_dict[field].df &&
 					frm.fields_dict[field].df.read_only
 				) {
-					if (debug && site.getEnvironment() !== 'development') console.debug(`Utils.makeReadOnly(): Preserving field "${field}" as readonly.`);
+					if (debug && site.getEnvironment() === 'development') console.debug(`Utils.makeReadOnly(): Preserving field "${field}" as readonly.`);
 					return;
 				}
 				console.log(`Setting ${field} to read_only: ${isExceptionState ? 0 : 1}`);
 				frm.set_df_property(field, "read_only", isExceptionState ? 0 : 1);
 				frm.refresh_field(field);
-			} else if (debug && site.getEnvironment() !== 'development') {
+			} else if (debug && site.getEnvironment() === 'development') {
 				console.warn(`Utils.makeReadOnly(): Field "${field}" does not exist in the form or cannot be set to read_only.`);
 			}
 		});

--- a/utils.js
+++ b/utils.js
@@ -1351,6 +1351,7 @@ const Utils = (function () {
 		 * definitive answer, it defaults to "production".
 		 *
 		 * @returns {string} Returns "development" if in a development environment, otherwise "production".
+		 * @since 1.5.0
 		 *
 		 * @example
 		 * // Logs the current environment ("development" or "production")

--- a/utils.js
+++ b/utils.js
@@ -379,7 +379,7 @@ const Utils = (function () {
 		}
 
 		if (!Array.isArray(fields)) {
-			if (debug && site.getEnvironment() !== 'development') console.warn("Utils.makeReadOnly(): 'fields' must be an array.");
+			if (debug && site.getEnvironment() === 'development') console.warn("Utils.makeReadOnly(): 'fields' must be an array.");
 			return [];
 		}
 


### PR DESCRIPTION
## [1.5.0] - 2025-04-07

### Added
  - **`site.getEnvironment()`:**
    - This method is meant to retrieve whether if you are in production or a dev environment (returns "development" or "production").

### Fixed
  - **`dubug` property:**
    - disabled all console logs and warning in production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a capability to detect the current environment (development or production) for a smoother user experience.
	- Added a section in the documentation detailing how to retrieve installed apps and their versions.
- **Bug Fixes**
	- Resolved issues that caused unintended logging in production environments.
- **Documentation**
	- Enhanced the documentation with clear examples on retrieving site information, including installed applications and environment status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->