### PR TITLE
fix: add new props `hideFields`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.7.0] - 2025-04-09
+
+### Added
+  - **New Props for `frappe.utilsPlus.hideFields`:**
+    - Added `conditional` and `debug` props
+
 ## [1.6.0] - 2025-04-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Utils.js is intended for use in any client script of your Frappe forms. Below ar
 // Retrieves tabs from the form (excluding hidden ones if specified)
 const { tabs, json } = getTabs({ excludeHidden: true });
 console.log("Tabs:", tabs);
---console.log("Tab Definitions:", json);
+console.log("Tab Definitions:", json);
 
 ```
 
@@ -200,8 +200,16 @@ frappe.utilsPlus.makeReadOnly({
 #### Hide Fields
 
 ```javascript
-// Hide fields "phone" and "email" unless the workflow state is "Draft"
-frappe.utilsPlus.hideFields({ fields: ["phone", "email"], exceptionStates: ["Draft"] });
+// Hide fields "phone" and "email" unless the workflow state is "Draft" and unhide for a specific user with a conditional function
+frappe.utilsPlus.hideFields({
+  fields: ["phone", "email"],
+  exceptionStates: ["Draft"],
+  conditional: () => {
+    let user = frappe.session.user
+    return user !== 'someuse@test.com'
+  },
+  debug: true
+});
 
 ```
 

--- a/utils.js
+++ b/utils.js
@@ -5,7 +5,7 @@
  * This module simplifies form navigation, field management, workflow actions and transition definition, action interception and site information.,
  * automatically operating on the global cur_frm.
  *
- * @version 1.6.0
+ * @version 1.7.0
  * 
  * @module Utils
  */
@@ -411,24 +411,34 @@ const Utils = (function () {
 	 * @param {Object} props - The configuration object.
 	 * @param {string[]} props.fields - Array of field names to hide.
 	 * @param {string[]} [props.exceptionStates=[]] - Array of workflow states during which the fields remain visible.
+	 * @param {function} props.conditional - If this is truthy the fields will be hidden.
 	 *
 	 * @example
 	 * // Hide fields "phone" and "email" unless the workflow state is "Draft"
 	 * Utils.hideFields({ fields: ["phone", "email"], exceptionStates: ["Draft"] });
 	 */
-	const hideFields = ({ fields = [], exceptionStates = [] } = {}) => {
+	const hideFields = (props) => {
+		const { fields = [], exceptionStates = [], debug, conditional } = props
+
 		const frm = cur_frm;
 		if (!frm?.doc || !frm.fields_dict) {
-			console.warn("Utils.hideFields(): Invalid Frappe form object provided.");
+			if (debug && site.getEnvironment() === 'development') console.warn("Utils.hideFields(): Invalid Frappe form object provided.");
 			return [];
 		}
+
+		if (!Array.isArray(fields)) {
+			if (debug && site.getEnvironment() === 'development') console.warn("Utils.hideFields(): 'fields' must be an array.");
+			return [];
+		}
+
 		const isExceptionState = exceptionStates.includes(frm.doc.workflow_state);
 		fields.forEach(field => {
 			if (frm.fields_dict[field]) {
-				frm.set_df_property(field, "hidden", isExceptionState ? 0 : 1);
+				if (debug && site.getEnvironment() === 'development') console.debug(`Setting ${field} to hidden: ${isExceptionState || conditional ? 0 : 1}`);
+				frm.set_df_property(field, "hidden", isExceptionState || conditional ? 0 : 1);
 				frm.refresh_field(field);
 			} else {
-				console.warn(`Utils.hideFields(): Field "${field}" does not exist in the form or cannot be hidden.`);
+				if (debug && site.getEnvironment() === 'development') console.warn(`Utils.hideFields(): Field "${field}" does not exist in the form or cannot be hidden.`);
 			}
 		});
 	}

--- a/utils.js
+++ b/utils.js
@@ -423,19 +423,25 @@ const Utils = (function () {
 		const frm = cur_frm;
 		if (!frm?.doc || !frm.fields_dict) {
 			if (debug && site.getEnvironment() === 'development') console.warn("Utils.hideFields(): Invalid Frappe form object provided.");
-			return [];
+			return;
 		}
 
 		if (!Array.isArray(fields)) {
 			if (debug && site.getEnvironment() === 'development') console.warn("Utils.hideFields(): 'fields' must be an array.");
-			return [];
+			return;
+		}
+
+		if (conditional !== undefined && typeof conditional !== 'function') {
+			if (debug && site.getEnvironment() === 'development') console.warn("Utils.hideFields(): 'conditional' must be a function.");
+			return;
 		}
 
 		const isExceptionState = exceptionStates.includes(frm.doc.workflow_state);
+
 		fields.forEach(field => {
 			if (frm.fields_dict[field]) {
-				if (debug && site.getEnvironment() === 'development') console.debug(`Setting ${field} to hidden: ${isExceptionState || conditional ? 0 : 1}`);
-				frm.set_df_property(field, "hidden", isExceptionState || conditional ? 0 : 1);
+				if (debug && site.getEnvironment() === 'development') console.debug(`Setting ${field} to hidden: ${isExceptionState || conditional() ? 0 : 1}`);
+				frm.set_df_property(field, "hidden", isExceptionState || conditional() ? 0 : 1);
 				frm.refresh_field(field);
 			} else {
 				if (debug && site.getEnvironment() === 'development') console.warn(`Utils.hideFields(): Field "${field}" does not exist in the form or cannot be hidden.`);


### PR DESCRIPTION
## [1.7.0] - 2025-04-09

### Added
  - **New Props for `frappe.utilsPlus.hideFields`:**
    - Added `conditional` and `debug` props

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced field visibility controls now determine if sensitive contact fields are shown based on workflow conditions and user permissions.
  - Introduced an improved troubleshooting mode with additional logging for deeper insights during operations.
  - Added new properties `conditional` and `debug` to the field hiding functionality.

- **Documentation**
  - Updated changelog and README to reflect new properties and their usage in the field hiding functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->