### PR TITLE
fix: prevent duplicate confirm dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.0.1] - 2025-04-09
+
+### Added
+  - **Duplicate Prevention Mechanism for `frappe.utilsPlus.action.confirm()`:**
+    - Added a check using a unique flag (based on the action name) to prevent multiple confirmation dialogs from being triggered for the same workflow action.
+
 ## [2.0.0] - 2025-04-09
 
 ### Added

--- a/utils.js
+++ b/utils.js
@@ -63,6 +63,32 @@ const Utils = (function () {
 	}
 
 	/**
+	 * Converts an input string to camelCase format.
+	 *
+	 * @private
+	 * @param {string} input - The input string to be converted (e.g., "Submit Application").
+	 * @returns {string} The camelCase string.
+	 *
+	 * @example
+	 * const result = toCamelCase("Submit Application");
+	 * console.log(result); // "submitApplication"
+	 */
+	const toCamelCase = (input) => {
+
+		const words = input.split(' ').filter(Boolean);
+
+		const camelCase = words
+			.map((word, index) => {
+				if (index === 0) return word.toLowerCase();
+				return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+			})
+			.join('');
+
+		return camelCase;
+	};
+
+
+	/**
 	 * Retrieves all "Tab Break" fields from the global form (cur_frm) and returns an object containing:
 	 * - an array of tab fieldnames,
 	 * - a JSON mapping of each tab fieldname to its corresponding field definition.
@@ -994,10 +1020,13 @@ const Utils = (function () {
 
 			if (!action) {
 				if (debug && site.getEnvironment() === 'development') {
-					if (debug && site.getEnvironment() === 'development') console.warn("Utils.action.confirm(): No action provided.");
+					console.warn("Utils.action.confirm(): No action provided.");
 				}
 				return;
 			}
+
+			if (frappe[`__${toCamelCase(action)}Confirm`]) return;
+			frappe[`__${toCamelCase(action)}Confirm`] = true
 
 			frappe.ui.form.on(cur_frm.doc.doctype, {
 				before_workflow_action: async () => {

--- a/utils.js
+++ b/utils.js
@@ -5,7 +5,7 @@
  * This module simplifies form navigation, field management, workflow actions and transition definition, action interception and site information.,
  * automatically operating on the global cur_frm.
  *
- * @version 2.0.0
+ * @version 2.0.1
  * 
  * @module Utils
  */


### PR DESCRIPTION
## [2.0.1] - 2025-04-09

### Added
  - **Duplicate Prevention Mechanism for `frappe.utilsPlus.action.confirm()`:**
    - Added a check using a unique flag (based on the action name) to prevent multiple confirmation dialogs from being triggered for the same workflow action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced confirmation dialogs that now prevent duplicate prompts for the same action, ensuring a smoother user experience.
  
- **Documentation**
  - Updated the changelog to reflect the new release version (2.0.1).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->