### PR TITLE
Feat return JQuery for tabButtons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [2.1.0] - 2025-04-11
+
+### Added
+  - **Disabled Prop for Custom Buttons:**
+    Added support for a new property `disable` (boolean) on custom button configuration objects. When set to `true`, the corresponding custom button is rendered with the HTML `disabled` attribute.
+
+  - **Data Attributes for Custom Buttons:**
+    Added the `data-label` attribute on custom buttons (populated with the button's label). This facilitates referencing the custom buttons by label in the returned object.
+
+  - **Return Object Structure:**
+    Updated the `addTabButtons()` function to return an object where each tab's key maps to a nested object containing jQuery objects for:
+      - `previous`: The previous button.
+      - `next`: The next button.
+      - Custom buttons: Mapped by their label (e.g., `"Submit": jqueryObj`).
+
+  - **Navigation Container Identification:**
+    Modified the navigation container markup to include a `data-tab` attribute, which ensures that the proper nav container is selected when retrieving button references.
+
+### Fixed
+  - **Custom Buttons Visibility:**
+    Resolved an issue where custom buttons were not displayed because the navigation container selector was expecting a `data-tab` attribute that was missing. With the updated markup, the custom buttons now appear as expected.
+
 ## [2.0.1] - 2025-04-09
 
 ### Added

--- a/utils.js
+++ b/utils.js
@@ -881,7 +881,8 @@ const Utils = (function () {
 							const variantClass = btn.variant && variantMapping[btn.variant]
 								? variantMapping[btn.variant]
 								: "btn-primary";
-							return `<button class="btn ${className} ${variantClass} float-right custom-tab-button" data-tab="${tabFieldname}" data-cb-index="${index}">${label}</button>`;
+							const disabledAttr = btn.disabled ? "disabled" : "";
+							return `<button class="btn ${className} ${variantClass} float-right custom-tab-button" data-tab="${tabFieldname}" data-cb-index="${index}" ${disabledAttr}>${label}</button>`;
 						})
 						.join(" ");
 				}

--- a/utils.js
+++ b/utils.js
@@ -850,6 +850,8 @@ const Utils = (function () {
 			$tab_nav.remove();
 		}
 		// Append navigation buttons to each .tab-pane.
+		const buttonRefs = {};
+
 		$(".tab-pane").each(function () {
 			const tabId = $(this).attr("id");
 			const tabFieldname = tabId.split("-").pop().replace("-tab", "");
@@ -882,7 +884,7 @@ const Utils = (function () {
 								? variantMapping[btn.variant]
 								: "btn-primary";
 							const disabledAttr = btn.disabled ? "disabled" : "";
-							return `<button class="btn ${className} ${variantClass} float-right custom-tab-button" data-tab="${tabFieldname}" data-cb-index="${index}" ${disabledAttr}>${label}</button>`;
+							return `<button class="btn ${className} ${variantClass} float-right custom-tab-button" data-tab="${tabFieldname}" data-cb-index="${index}" data-label="${label}" ${disabledAttr}>${label}</button>`;
 						})
 						.join(" ");
 				}
@@ -897,7 +899,7 @@ const Utils = (function () {
 						: `<button class="btn btn-primary ${className} float-right invisible" disabled>Next</button>`;
 
 			const buttonHtml = `
-		  <div class="flex form-section-buttons justify-between nav-buttons w-100">
+		  <div class="flex form-section-buttons justify-between nav-buttons w-100" data-tab="${tabFieldname}">
 			<div class="flex section-body w-100 py-3">
 			  <div class="form-column col-sm-6">
 				${previousButtonHTML}
@@ -909,6 +911,23 @@ const Utils = (function () {
 		  </div>
 		`;
 			$(this).append(buttonHtml);
+
+			const $nav = $(this).find(`.nav-buttons[data-tab="${tabFieldname}"]`);
+			const prevButton = $nav.find('button[data-direction="previous"]');
+			const nextButton = $nav.find('button[data-direction="next"]');
+			const customButtons = $nav.find('button.custom-tab-button');
+			console.log(customButtons)
+
+			buttonRefs[tabFieldname] = {
+				previous: prevButton,
+				next: nextButton
+			};
+
+			customButtons.each(function (index, elem) {
+				const btnLabel = $(elem).data("label");
+				buttonRefs[tabFieldname][btnLabel] = $(elem);
+				console.log($(elem))
+			});
 		});
 
 		// Event handler for navigation buttons (Previous/Next).
@@ -952,6 +971,8 @@ const Utils = (function () {
 				if (props.debug && site.getEnvironment() === 'development') console.log("Custom button clicked on tab " + tab);
 			}
 		});
+
+		return buttonRefs;
 	}
 
 

--- a/utils.js
+++ b/utils.js
@@ -5,7 +5,7 @@
  * This module simplifies form navigation, field management, workflow actions and transition definition, action interception and site information.,
  * automatically operating on the global cur_frm.
  *
- * @version 2.0.2
+ * @version 2.1.0
  * 
  * @module Utils
  */

--- a/utils.js
+++ b/utils.js
@@ -916,7 +916,6 @@ const Utils = (function () {
 			const prevButton = $nav.find('button[data-direction="previous"]');
 			const nextButton = $nav.find('button[data-direction="next"]');
 			const customButtons = $nav.find('button.custom-tab-button');
-			console.log(customButtons)
 
 			buttonRefs[tabFieldname] = {
 				previous: prevButton,
@@ -926,7 +925,6 @@ const Utils = (function () {
 			customButtons.each(function (index, elem) {
 				const btnLabel = $(elem).data("label");
 				buttonRefs[tabFieldname][btnLabel] = $(elem);
-				console.log($(elem))
 			});
 		});
 


### PR DESCRIPTION
## [2.1.0] - 2025-04-11

### Added
  - **Disabled Prop for Custom Buttons:**
    Added support for a new property `disable` (boolean) on custom button configuration objects. When set to `true`, the corresponding custom button is rendered with the HTML `disabled` attribute.

  - **Data Attributes for Custom Buttons:**
    Added the `data-label` attribute on custom buttons (populated with the button's label). This facilitates referencing the custom buttons by label in the returned object.

  - **Return Object Structure:**
    Updated the `addTabButtons()` function to return an object where each tab's key maps to a nested object containing jQuery objects for:
      - `previous`: The previous button.
      - `next`: The next button.
      - Custom buttons: Mapped by their label (e.g., `"Submit": jqueryObj`).

  - **Navigation Container Identification:**
    Modified the navigation container markup to include a `data-tab` attribute, which ensures that the proper nav container is selected when retrieving button references.

### Fixed
  - **Custom Buttons Visibility:**
    Resolved an issue where custom buttons were not displayed because the navigation container selector was expecting a `data-tab` attribute that was missing. With the updated markup, the custom buttons now appear as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Custom buttons now support a disabled state and include a label attribute for better identification.
	- The navigation area has been updated for improved button grouping and management.
	- Enhanced return structure for tab button creation, providing easier access to button references.
- **Bug Fixes**
	- Fixed an issue that prevented custom buttons from displaying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->