### PR TITLE
Fix add variant for custom tab buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.1.1] - 2025-04-11
+
+### Fixed
+  - add missing variant for custom tab buttons: `success`
+   
+
 ## [2.1.0] - 2025-04-11
 
 ### Added

--- a/utils.js
+++ b/utils.js
@@ -5,7 +5,7 @@
  * This module simplifies form navigation, field management, workflow actions and transition definition, action interception and site information.,
  * automatically operating on the global cur_frm.
  *
- * @version 2.1.0
+ * @version 2.1.1
  * 
  * @module Utils
  */
@@ -837,6 +837,7 @@ const Utils = (function () {
 			primary: "btn-primary",
 			secondary: "btn-secondary",
 			destructive: "btn-danger",
+			success: "btn-success",
 			outline: "btn-outline",
 			ghost: "btn-ghost"
 		};


### PR DESCRIPTION
## [2.1.1] - 2025-04-11

### Fixed
  - add missing variant for custom tab buttons: `success`
   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue with custom tab buttons by adding the missing "success" styling option for a more consistent UI experience.

- **Chores**
  - Updated the release version to 2.1.1, ensuring accurate version documentation for this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->