### PR TITLE
hotfix: prevent double clicking for tab navigation buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
   - **Tab Content bleeding into each other:**
-  - prevent double clicking for tab navigation buttons, clicking in rapid succession caused rending issues after saving triggers `frappe.dom.freeze()`
+    - prevent double clicking for tab navigation buttons, clicking in rapid succession caused rendering issues after saving triggers `frappe.dom.freeze()`
 
 ## [2.2.0] - 2025-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.2.1] - 2025-04-14
+
+### Fixed
+  - **Tab Content bleeding into each other:**
+  - prevent double clicking for tab navigation buttons, clicking in rapid succession caused rending issues after saving triggers `frappe.dom.freeze()`
+
 ## [2.2.0] - 2025-04-12
 
 ### Added

--- a/utils.js
+++ b/utils.js
@@ -5,7 +5,7 @@
  * This module simplifies form navigation, field management, workflow actions and transition definition, action interception and site information.,
  * automatically operating on the global cur_frm.
  *
- * @version 2.2.0
+ * @version 2.2.1
  * 
  * @module Utils
  */

--- a/utils.js
+++ b/utils.js
@@ -934,7 +934,12 @@ const Utils = (function () {
 		});
 
 		// Event handler for navigation buttons (Previous/Next).
+		$(document).off("click", ".tab-navigation");
 		$(document).on("click", ".tab-navigation", function () {
+			$(this).prop('disabled', true)
+			setTimeout(() => {
+				$(this).prop('disabled', false)
+			}, 1000);
 			const direction = $(this).data("direction");
 			const currentTabFieldname = $("#form-tabs li a.active").data("fieldname");
 			const saveTabs = props.saveTabs || [];
@@ -956,6 +961,10 @@ const Utils = (function () {
 		// Event handler for custom buttons.
 		$(document).off("click", ".custom-tab-button");
 		$(document).on("click", ".custom-tab-button", function () {
+			$(this).prop('disabled', true)
+			setTimeout(() => {
+				$(this).prop('disabled', false)
+			}, 1000);
 			const tab = $(this).data("tab");
 			const cbIndex = parseInt($(this).data("cb-index"), 10);
 			const applicableButtons = (props.buttons || []).filter(function (btn) {


### PR DESCRIPTION
## [2.2.1] - 2025-04-14

### Fixed
  - **Tab Content bleeding into each other:**
  - prevent double clicking for tab navigation buttons, clicking in rapid succession caused rending issues after saving triggers `frappe.dom.freeze()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where rapidly double-clicking tab navigation buttons could cause tab content to overlap or display incorrectly. Buttons are now temporarily disabled after each click to prevent this behavior.

- **Chores**
  - Updated version number to 2.2.1 in documentation and module header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->