### PR TITLE
Feat: action compose email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.4.0] - 2025-07-27
+
+### Added
+- **`action.composeEmail` Action Interceptor:**
+  - Introduced a new `action.composeEmail` function to intercept a workflow action and require the user to send an email via the `CommunicationComposer` before the action proceeds.
+  - Includes a `setValue` property to update multiple document fields after the user initiates the send action but before the workflow proceeds.
+
 ## [2.2.2] - 2025-04-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -338,6 +338,34 @@ frappe.utilsPlus.action.confirm({
 });
 
 ```
+
+#### Compose Email
+
+This feature intercepts a workflow action, enabling the user to compose and send an email before proceeding with the action.
+
+```javascript
+frappe.ui.form.on("Leave Application", {
+    refresh: function(frm) {
+        frappe.utilsPlus.action.composeEmail({
+            action: "Reject",
+            debug: true,
+            composer_args: {
+                recipients: frm.doc.owner,
+                subject: `Update on your Leave Application: ${frm.doc.name}`,
+                message: `Hello,<br><br>
+                          We are unable to approve your leave application for the following reason(s):
+                          <br><br>
+                          <ul>
+                            <li>...</li>
+                          </ul>
+                          <br>
+                          Thank you.`
+            }
+        });
+    }
+});
+```
+
 ### Workflow Transition and Action Retrieval
 
 #### Retrieve all workflow transition

--- a/utils.js
+++ b/utils.js
@@ -5,7 +5,7 @@
  * This module simplifies form navigation, field management, workflow actions and transition definition, action interception and site information.,
  * automatically operating on the global cur_frm.
  *
- * @version 2.3.0
+ * @version 2.4.0
  *
  * @module Utils
  */


### PR DESCRIPTION
## [2.4.0] - 2025-07-27

### Added
- **`action.composeEmail` Action Interceptor:**
  - Introduced a new `action.composeEmail` function to intercept a workflow action and require the user to send an email via the `CommunicationComposer` before the action proceeds.
  - Includes a `setValue` property to update multiple document fields after the user initiates the send action but before the workflow proceeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new workflow action interceptor that requires users to compose and send an email before certain actions can proceed.
  * Added the ability to update multiple document fields after sending the email but before continuing the workflow.

* **Documentation**
  * Updated the changelog with details of version 2.4.0.
  * Added a new section to the documentation explaining how to use the email composition workflow interception feature, including usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->