### PR TITLE
hotfix: active tab detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.4.1] - 2025-08-28
+
+### Fixed
+- **Tab Navigation:**
+  - ***Active tab detection**: In preparation for version 16 [Frappe Framework](https://github.com/frappe/frappe) has changed the tab links from links to button (`#form-tabs li a` -> `#form-tabs li button`) this broke my active tab detection because I was doing a jquery for `#form-tabs li a.active`. I will decouple the active tab detection from the ui eventually but for now I have hotfixed it `#form-tabs li a.active` -> `#form-tabs li .active`.
+
 ## [2.4.0] - 2025-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## [2.4.1] - 2025-08-28
 
 ### Fixed
-- **Tab Navigation:**
-  - ***Active tab detection**: In preparation for version 16 [Frappe Framework](https://github.com/frappe/frappe) has changed the tab links from links to button (`#form-tabs li a` -> `#form-tabs li button`) this broke my active tab detection because I was doing a jquery for `#form-tabs li a.active`. I will decouple the active tab detection from the ui eventually but for now I have hotfixed it `#form-tabs li a.active` -> `#form-tabs li .active`.
+- **Tab Navigation**
+  - **Active tab detection**: In Frappe Framework v16, tab controls changed from anchors to buttons (`#form-tabs li a` → `#form-tabs li button`). This broke active-tab detection that relied on `#form-tabs li a.active`. As a hotfix, the selector is broadened to `#form-tabs li .active`. A future release will decouple active-tab detection from the UI.
 
 ## [2.4.0] - 2025-07-27
 

--- a/utils.js
+++ b/utils.js
@@ -5,7 +5,7 @@
  * This module simplifies form navigation, field management, workflow actions and transition definition, action interception and site information.,
  * automatically operating on the global cur_frm.
  *
- * @version 2.4.0
+ * @version 2.4.1
  *
  * @module Utils
  */
@@ -739,7 +739,7 @@ const Utils = (function () {
 				);
 			return;
 		}
-		const activeTabLink = $("#form-tabs li a.active");
+		const activeTabLink = $("#form-tabs li .active");
 		if (!activeTabLink.length) {
 			if (debug && site.getEnvironment() === "development")
 				console.warn("Utils.goToTab.next(): No active tab found.");
@@ -788,7 +788,7 @@ const Utils = (function () {
 				);
 			return;
 		}
-		const activeTabLink = $("#form-tabs li a.active");
+		const activeTabLink = $("#form-tabs li .active");
 		if (!activeTabLink.length) {
 			if (debug && site.getEnvironment() === "development")
 				console.warn("Utils.goToTab.previous(): No active tab found.");
@@ -897,7 +897,7 @@ const Utils = (function () {
 				console.warn("Utils.hasNextTab(): No tabs found in the form.");
 			return { hasNext: false, nextTab: null };
 		}
-		const activeTabLink = $("#form-tabs li a.active");
+		const activeTabLink = $("#form-tabs li .active");
 		if (!activeTabLink.length) {
 			if (debug && site.getEnvironment() === "development")
 				console.warn("Utils.hasNextTab(): No active tab found.");
@@ -945,7 +945,7 @@ const Utils = (function () {
 				);
 			return { hasPrevious: false, previousTab: null };
 		}
-		const activeTabLink = $("#form-tabs li a.active");
+		const activeTabLink = $("#form-tabs li .active");
 		if (!activeTabLink.length) {
 			if (debug && site.getEnvironment() === "development")
 				console.warn("Utils.hasPreviousTab(): No active tab found.");
@@ -1159,7 +1159,7 @@ const Utils = (function () {
 				$(this).prop("disabled", false);
 			}, 1000);
 			const direction = $(this).data("direction");
-			const currentTabFieldname = $("#form-tabs li a.active").data(
+			const currentTabFieldname = $("#form-tabs li .active").data(
 				"fieldname"
 			);
 			const saveTabs = props.saveTabs || [];


### PR DESCRIPTION
## [2.4.1] - 2025-08-28

### Fixed
- **Tab Navigation:**
  - ***Active tab detection**: In preparation for v16 [Frappe Framework](https://github.com/frappe/frappe) has changed the tab links from links to buttons (`#form-tabs li a` -> `#form-tabs li button`) this broke my active tab detection because I was doing a jquery for `#form-tabs li a.active`. I will decouple the active tab detection from the ui eventually but for now I have hotfixed it `#form-tabs li a.active` -> `#form-tabs li .active`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored reliable tab navigation in forms: Next/Previous actions now correctly detect the active tab.
  * Active tab highlighting works regardless of whether tabs render as links or buttons.
  * Ensures smooth navigation across all tabs without misselection.

* **Chores**
  * Bumped version to 2.4.1.
  * Added CHANGELOG entry for 2.4.1 (2025-08-28).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->